### PR TITLE
remove watch flag

### DIFF
--- a/dka-scraper.config.cjs
+++ b/dka-scraper.config.cjs
@@ -1,10 +1,11 @@
 module.exports = {
-  apps : [{
-    name   : "DKA_SCRAPER",
-    script : "npm",
-    args : "run start --prefix /home/dka/scraper",
-    watch : true,
-    cron: "0 3 * * *",
-    autorestart: false
-  }]
-}
+  apps: [
+    {
+      name: "DKA_SCRAPER",
+      script: "npm",
+      args: "run start --prefix /home/dka/scraper",
+      cron: "0 3 * * *",
+      autorestart: false,
+    },
+  ],
+};


### PR DESCRIPTION
Watch flag was making pm2 restart the app because error logs were written to files.